### PR TITLE
change target of font-size in style.css to html-tag

### DIFF
--- a/res/css/style.css
+++ b/res/css/style.css
@@ -4,9 +4,10 @@
   box-sizing: border-box;
   max-width: 1920px;
 }
-
+html {
+  font-size: 62.5%;
+}
 body {
   background-color: #fff;
-  font-size: 62.5%;
   font-family: "Roboto", sans-serif;
 }


### PR DESCRIPTION
If we want to set the **default font-size** to 62.5% it has to be set for the **html elment** itself 
--> so for example **rem inherits only from root = html elment**


